### PR TITLE
Bouncy castle 1.77 upgrade

### DIFF
--- a/commons/build.gradle
+++ b/commons/build.gradle
@@ -22,12 +22,12 @@ xjc{
 }
 
 dependencies {
-    implementation ('org.apache.santuario:xmlsec:2.3.0') {
+    implementation ('org.apache.santuario:xmlsec:4.0.2') {
         exclude group: 'org.codehaus.woodstox'
         exclude group: 'org.slf4j'
     }
-    implementation 'org.bouncycastle:bcpkix-jdk15on:1.59'
-    implementation 'org.json:json:20211205'
+    implementation 'org.bouncycastle:bcpkix-jdk15on:1.68'
+    implementation 'org.json:json:20240303'
     implementation 'jakarta.xml.bind:jakarta.xml.bind-api:3.0.1'
     implementation 'com.sun.xml.bind:jaxb-impl:3.0.2'
     implementation 'com.sun.xml.ws:jaxws-rt:3.0.2'

--- a/commons/build.gradle
+++ b/commons/build.gradle
@@ -26,7 +26,7 @@ dependencies {
         exclude group: 'org.codehaus.woodstox'
         exclude group: 'org.slf4j'
     }
-    implementation 'org.bouncycastle:bcpkix-jdk15on:1.68'
+    implementation 'org.bouncycastle:bcpkix-jdk18on:1.77'
     implementation 'org.json:json:20240303'
     implementation 'jakarta.xml.bind:jakarta.xml.bind-api:3.0.1'
     implementation 'com.sun.xml.bind:jaxb-impl:3.0.2'

--- a/commons/src/main/java/de/bund/bsi/tr_esor/checktool/data/ArchiveTimeStamp.java
+++ b/commons/src/main/java/de/bund/bsi/tr_esor/checktool/data/ArchiveTimeStamp.java
@@ -95,7 +95,7 @@ public class ArchiveTimeStamp implements ASN1Encodable
         {
           case TAGNO_DIGESTALGO:
             indexOfLastElementInDef = checkSequence(indexOfLastElementInDef, 1);
-            digestAlgo = ASN1Utils.parseAlgorithmIdentifier(tagged.getObject());
+            digestAlgo = ASN1Utils.parseAlgorithmIdentifier(tagged.getBaseObject());
             break;
           case TAGNO_ATTRIBUTES:
             indexOfLastElementInDef = checkSequence(indexOfLastElementInDef, 2);
@@ -157,13 +157,14 @@ public class ArchiveTimeStamp implements ASN1Encodable
   {
     // This tag is implicit, if only one attribute is present, the data is recognized as ASN1Sequence
     // (outer element of an attribute).
-    if (t.getObject() instanceof ASN1Sequence)
+
+    if (t.getBaseObject() instanceof ASN1Sequence)
     {
-      attributes = Attributes.getInstance(new DLSet(t.getObject()));
+      attributes = Attributes.getInstance(new DLSet(t.getBaseObject()));
     }
-    else if (t.getObject() instanceof ASN1Set)
+    else if (t.getBaseObject() instanceof ASN1Set)
     {
-      attributes = Attributes.getInstance(t.getObject());
+      attributes = Attributes.getInstance(t.getBaseObject());
     }
     else
     {

--- a/commons/src/main/java/de/bund/bsi/tr_esor/checktool/data/ArchiveTimeStamp.java
+++ b/commons/src/main/java/de/bund/bsi/tr_esor/checktool/data/ArchiveTimeStamp.java
@@ -88,9 +88,9 @@ public class ArchiveTimeStamp implements ASN1Encodable
     var indexOfLastElementInDef = -1; // number of element in definition, some may be skipped
     for ( var element : Checked.cast(obj).to(ASN1Sequence.class) )
     {
-      if (element instanceof DERTaggedObject)
+      if (element instanceof ASN1TaggedObject)
       {
-        var tagged = (DERTaggedObject)element;
+        var tagged = (ASN1TaggedObject)element;
         switch (tagged.getTagNo())
         {
           case TAGNO_DIGESTALGO:

--- a/commons/src/main/java/de/bund/bsi/tr_esor/checktool/entry/CmsSignedDataReader.java
+++ b/commons/src/main/java/de/bund/bsi/tr_esor/checktool/entry/CmsSignedDataReader.java
@@ -21,12 +21,10 @@
  */
 package de.bund.bsi.tr_esor.checktool.entry;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import de.bund.bsi.tr_esor.checktool.data.ASN1Utils;
+import de.bund.bsi.tr_esor.checktool.data.EvidenceRecord;
+import de.bund.bsi.tr_esor.checktool.parser.ASN1EvidenceRecordParser;
+import de.bund.bsi.tr_esor.checktool.validation.report.Reference;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.cms.Attribute;
 import org.bouncycastle.cms.CMSSignedData;
@@ -34,10 +32,11 @@ import org.bouncycastle.cms.SignerId;
 import org.bouncycastle.cms.SignerInformation;
 import org.bouncycastle.cms.SignerInformationStore;
 
-import de.bund.bsi.tr_esor.checktool.data.ASN1Utils;
-import de.bund.bsi.tr_esor.checktool.data.EvidenceRecord;
-import de.bund.bsi.tr_esor.checktool.parser.ASN1EvidenceRecordParser;
-import de.bund.bsi.tr_esor.checktool.validation.report.Reference;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 
 /**

--- a/commons/src/main/java/de/bund/bsi/tr_esor/checktool/validation/default_impl/basis/ers/ContentInfoChecker.java
+++ b/commons/src/main/java/de/bund/bsi/tr_esor/checktool/validation/default_impl/basis/ers/ContentInfoChecker.java
@@ -283,7 +283,7 @@ public class ContentInfoChecker
 
   private OtherRevocationInfoFormat extractOrif(Object obj)
   {
-    Object orif = obj instanceof ASN1TaggedObject ? ((ASN1TaggedObject)obj).getObject() : null;
+    Object orif = obj instanceof ASN1TaggedObject ? ((ASN1TaggedObject)obj).getBaseObject() : null;
     return OtherRevocationInfoFormat.getInstance(orif);
   }
 

--- a/commons/src/test/java/de/bund/bsi/tr_esor/checktool/validation/default_impl/basis/ers/TestContentInfoChecker.java
+++ b/commons/src/test/java/de/bund/bsi/tr_esor/checktool/validation/default_impl/basis/ers/TestContentInfoChecker.java
@@ -306,7 +306,7 @@ public class TestContentInfoChecker
       : ContentInfoChecker.OID_BASIC_OSCP_RESPONSE));
     var mockOCSPResponse = mockOCSPResponse(valid);
     otherRevVector.add(wrongElement ? null : mockOCSPResponse);
-    when(tag.getObject()).thenReturn(new DLSequence(otherRevVector));
+    when(tag.getBaseObject()).thenReturn(new DLSequence(otherRevVector));
     return tag;
   }
 


### PR DESCRIPTION
Warning: The 2 tests
* erInCmsDetached
* erInCmsEncapsulated

Fail due to some issue around cmsWithout(). Problem lies with DERNull/DLNULL being serialized to [5, 0] whereas actual null is serialized to [].

My suspicion is, that this (ran in the debugger at the end of signWithout in the erInCmsEncapsulated test) is the problem:
![image](https://github.com/de-bund-bsi-tr-esor/ERVerifyTool/assets/9084941/8a9effac-8b20-43c3-a248-5f00ffa1b1fe)

If you run this in the debugger:
```
((AlgorithmIdentifier)CMSSignedData.replaceSigners(cms, new SignerInformationStore(si)).signedData.digestAlgorithms.elements[0]).parameters = DERNull.INSTANCE;
```
The test suddenly passes, but most of those properties are not writeable / only accessible in the debugger.